### PR TITLE
swift.php correction email html body display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - git clone --depth=50 --branch=master git://github.com/aimeos/aimeos-core.git ../aimeos-core
   - cd ../aimeos-core
   - mv ../ai-swiftmailer ext/
-  - composer require "swiftmailer/swiftmailer" ">=4.0"
+  - composer require "swiftmailer/swiftmailer" "~6.0"
 
 script:
   - vendor/bin/phing -Ddir=ext/ai-swiftmailer coverageext checkext

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,27 @@ php:
   - 5.5
   - 5.4
 
+
+env:
+  - VERSION=6.*
+  - VERSION=5.*
+  - VERSION=4.*
+
 matrix:
   fast_finish: true
+  exclude:
+    - php: 5.6
+      env: VERSION=6.*
+    - php: 5.5
+      env: VERSION=6.*
+    - php: 5.4
+      env: VERSION=6.*
 
 before_script:
   - git clone --depth=50 --branch=master git://github.com/aimeos/aimeos-core.git ../aimeos-core
   - cd ../aimeos-core
   - mv ../ai-swiftmailer ext/
-  - composer require "swiftmailer/swiftmailer" "~6.0"
+  - composer require "swiftmailer/swiftmailer" "${VERSION}"
 
 script:
   - vendor/bin/phing -Ddir=ext/ai-swiftmailer coverageext checkext

--- a/lib/custom/src/MW/Mail/Message/Swift.php
+++ b/lib/custom/src/MW/Mail/Message/Swift.php
@@ -156,7 +156,7 @@ class Swift implements \Aimeos\MW\Mail\Message\Iface
 	 */
 	public function setBody( $message )
 	{
-		$this->object->setBody( $message );
+		$this->object->addPart($message, 'text/plain');
 		return $this;
 	}
 
@@ -169,7 +169,7 @@ class Swift implements \Aimeos\MW\Mail\Message\Iface
 	 */
 	public function setBodyHtml( $message )
 	{
-		$this->object->addPart( $message, 'text/html' );
+		$this->object->setBody( $message, 'text/html' );
 		return $this;
 	}
 

--- a/lib/custom/tests/MW/Mail/Message/SwiftTest.php
+++ b/lib/custom/tests/MW/Mail/Message/SwiftTest.php
@@ -125,7 +125,7 @@ class SwiftTest extends \PHPUnit\Framework\TestCase
 
 	public function testSetBody()
 	{
-		$this->mock->expects( $this->once() )->method( 'setBody' )
+		$this->mock->expects( $this->once() )->method( 'addPart' )
 			->with( $this->stringContains( 'test' ) );
 
 		$result = $this->object->setBody( 'test' );
@@ -135,7 +135,7 @@ class SwiftTest extends \PHPUnit\Framework\TestCase
 
 	public function testSetBodyHtml()
 	{
-		$this->mock->expects( $this->once() )->method( 'addPart' )
+		$this->mock->expects( $this->once() )->method( 'setBody' )
 			->with( $this->stringContains( 'test' ) );
 
 		$result = $this->object->setBodyHtml( 'test' );


### PR DESCRIPTION
html body as default specified now with text as fallback for email